### PR TITLE
rename_package.bash

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -33,8 +33,7 @@ editing `gradle.properties`.
 * Rename the package
 
 ```
-NEW_PACKAGE_NAME=my.company.and.project
-./rename_package.bash $NEW_PACKAGE_NAME
+NEW_PACKAGE_NAME=my.company.and.project /bin/bash rename_package.bash $NEW_PACKAGE_NAME
 ```
 
 (The `rename_package.bash` script is very hacky. It also relies on


### PR DESCRIPTION
- The `rename_package.bash` file is not executable
- also the code was split into two lines, which doesn't work.

btw, I get an error on macOS Mojave:
 `sed: 1: "build.gradle": undefined label 'uild.gradle'`